### PR TITLE
FIX comparison logic in isChanged in editable columns

### DIFF
--- a/src/GridFieldEditableColumns.php
+++ b/src/GridFieldEditableColumns.php
@@ -339,11 +339,35 @@ class GridFieldEditableColumns extends GridFieldDataColumns implements
     private function isChanged(DataObject $item, array $fields): bool
     {
         foreach ($fields as $name => $value) {
-            if ($item->getField($name) !== $value) {
+            if ($this->normaliseValue($item->getField($name)) !== $this->normaliseValue($value)) {
                 return true;
             }
         }
 
         return false;
+    }
+
+    /**
+     * Normalise values before comparison in isChanged().
+     *
+     * Arrays are normalised recursively, numeric strings are cast to numbers,
+     * and booleans are converted to integers so equivalent submitted values
+     * don't trigger false-positive changes.
+     */
+    private function normaliseValue(mixed $value): mixed
+    {
+        if (is_array($value)) {
+            return array_map([$this, 'normaliseValue'], $value);
+        }
+
+        if (is_numeric($value)) {
+            return $value + 0;
+        }
+
+        if (is_bool($value)) {
+            return (int)$value;
+        }
+
+        return $value;
     }
 }

--- a/tests/GridFieldEditableColumnsTest.php
+++ b/tests/GridFieldEditableColumnsTest.php
@@ -5,15 +5,38 @@ namespace Symbiote\GridFieldExtensions\Tests;
 use Symbiote\GridFieldExtensions\Tests\Stub\TestController;
 use Symbiote\GridFieldExtensions\Tests\Stub\StubUnorderable;
 use Symbiote\GridFieldExtensions\GridFieldEditableColumns;
+use SilverStripe\ORM\DataObject;
 use SilverStripe\ORM\FieldType\DBHTMLText;
-use SilverStripe\Forms\TextField;
 use SilverStripe\Forms\GridField\GridField;
 use SilverStripe\Forms\Form;
 use SilverStripe\Forms\FieldList;
 use SilverStripe\Dev\SapphireTest;
+use ReflectionMethod;
 
 class GridFieldEditableColumnsTest extends SapphireTest
 {
+    /**
+     * Allow access to GridFieldEditableColumns::normaliseValue
+     */
+    private function invokeNormaliseValue(GridFieldEditableColumns $component, mixed $value): mixed
+    {
+        $method = new ReflectionMethod(GridFieldEditableColumns::class, 'normaliseValue');
+        $method->setAccessible(true);
+
+        return $method->invoke($component, $value);
+    }
+
+    /**
+     * Allow access to GridFieldEditableColumns::isChanged
+     */
+    private function invokeIsChanged(GridFieldEditableColumns $component, DataObject $item, array $fields): bool
+    {
+        $method = new ReflectionMethod(GridFieldEditableColumns::class, 'isChanged');
+        $method->setAccessible(true);
+
+        return $method->invoke($component, $item, $fields);
+    }
+
     private function getMockGrid()
     {
         $controller = new TestController('Test');
@@ -90,5 +113,69 @@ class GridFieldEditableColumnsTest extends SapphireTest
             '/<span[^>]*>\s*testval\s*<\/span>/',
             $column->getValue()
         );
+    }
+
+    public function testNormaliseValueCastsNumericStrings()
+    {
+        $component = new GridFieldEditableColumns();
+
+        $this->assertSame(10, $this->invokeNormaliseValue($component, '10'));
+        $this->assertSame(10.5, $this->invokeNormaliseValue($component, '10.5'));
+    }
+
+    public function testNormaliseValueConvertsBooleansToIntegers()
+    {
+        $component = new GridFieldEditableColumns();
+
+        $this->assertSame(1, $this->invokeNormaliseValue($component, true));
+        $this->assertSame(0, $this->invokeNormaliseValue($component, false));
+    }
+
+    public function testNormaliseValueRecursivelyNormalisesArrays()
+    {
+        $component = new GridFieldEditableColumns();
+
+        $result = $this->invokeNormaliseValue($component, [
+            '1',
+            true,
+            ['2', false, 'text'],
+        ]);
+
+        $this->assertSame([1, 1, [2, 0, 'text']], $result);
+    }
+
+    public function testIsChangedReturnsFalseForEquivalentNormalisedScalarValues()
+    {
+        $component = new GridFieldEditableColumns();
+        $item = new StubUnorderable();
+        $item->setField('Title', 'test');
+        $item->setField('Sort', 3);
+
+        $this->assertFalse($this->invokeIsChanged($component, $item, [
+            'Title' => 'test',
+            'Sort' => '3',
+        ]));
+    }
+
+    public function testIsChangedReturnsFalseForEquivalentNormalisedArrayValues()
+    {
+        $component = new GridFieldEditableColumns();
+        $item = new StubUnorderable();
+        $item->setField('IDs', [1, 2, 3]);
+
+        $this->assertFalse($this->invokeIsChanged($component, $item, [
+            'IDs' => ['1', '2', '3'],
+        ]));
+    }
+
+    public function testIsChangedReturnsTrueForDifferentValues()
+    {
+        $component = new GridFieldEditableColumns();
+        $item = new StubUnorderable();
+        $item->setField('Sort', 3);
+
+        $this->assertTrue($this->invokeIsChanged($component, $item, [
+            'Sort' => '4',
+        ]));
     }
 }


### PR DESCRIPTION
<!--
  Thanks for contributing, you're awesome! ⭐

  Please read https://docs.silverstripe.org/en/contributing/code/ if you haven't contributed to this project recently.
-->
## Description
<!--
  Please describe expected and observed behaviour, and what you're fixing.
  For visual fixes, please include tested browsers and screenshots.
-->
The changes introduced in [https://github.com/silverstripe/silverstripe-gridfieldextensions/pull/341](https://github.com/silverstripe/silverstripe-gridfieldextensions/pull/341) were intended to prevent re-saving unchanged records, ensuring that only modified data is persisted and avoiding potential timeouts during the save process.

However, this behaviour no longer works as expected due to a subsequent change made to address another issue: [https://github.com/silverstripe/silverstripe-gridfieldextensions/commit/f56bf67e40df84622ab587882fe54cf9cd0ab611](https://github.com/silverstripe/silverstripe-gridfieldextensions/commit/f56bf67e40df84622ab587882fe54cf9cd0ab611).

We are seeing the impact of this in user-defined forms. When a form is submitted, all fields are being re-saved, even if no changes were made. The root cause appears to be the `Sort` database field being submitted as a string (e.g. `"1"`), while it is stored as an integer in the database. This type mismatch causes the `isChanged` method to incorrectly detect a change, resulting in all fields being unnecessarily re-saved.

## Manual testing steps
<!--
  Include any manual testing steps here which a reviewer can perform to validate your pull request works correctly.
  Note that this DOES NOT replace unit or end-to-end tests.
-->
1. Install fresh CMS
2. Add the gridfield extensions module.
3. Add userform module
4. Create a userform with large number of form fields
5. Make a change to one of the fields
6. Save the userform.
7.  The form should save fast without timeout

Testing saving many_many/has_many relations
1. Create user form
2. Add radio button field
3. Add options to radio button
4. Save the form field
5. You should be able to save without any issues

## Issues
<!--
  List all issues here that this pull request fixes/resolves.
  If there is no issue already, create a new one! You must link your pull request to at least one issue.
-->
- #https://github.com/silverstripe/silverstripe-gridfieldextensions/issues/471

## Pull request checklist
<!--
  PLEASE check each of these to ensure you have done everything you need to do!
  If there's something in this list you need help with, please ask so that we can assist you.
-->
- [x] The target branch is correct
    - See [picking the right version](https://docs.silverstripe.org/en/contributing/code/#picking-the-right-version)
- [x] All commits are relevant to the purpose of the PR (e.g. no debug statements, unrelated refactoring, or arbitrary linting)
    - Small amounts of additional linting are usually okay, but if it makes it hard to concentrate on the relevant changes, ask for the unrelated changes to be reverted, and submitted as a separate PR.
- [x] The commit messages follow our [commit message guidelines](https://docs.silverstripe.org/en/contributing/code/#commit-messages)
- [x] The PR follows our [contribution guidelines](https://docs.silverstripe.org/en/contributing/code/)
- [x] Code changes follow our [coding conventions](https://docs.silverstripe.org/en/contributing/coding_conventions/)
- [x] This change is covered with tests (or tests aren't necessary for this change)
- [x] Any relevant User Help/Developer documentation is updated; for impactful changes, information is added to the changelog for the intended release
- [x] CI is green
